### PR TITLE
Fix codecov coverage upload

### DIFF
--- a/.github/workflows/build-commits.yml
+++ b/.github/workflows/build-commits.yml
@@ -39,7 +39,7 @@ jobs:
       - run: go mod download
       - run: go vet ./pkg
       - run: |
-          go test -v -vet=off -race -shuffle ${SHUFFLE_SEED} -coverprofile=coverage.out -covermode=atomic ./pkg
+          go test -v -vet=off -race -shuffle ${SHUFFLE_SEED} -coverprofile=coverage.txt -covermode=atomic ./pkg
         env:
           SHUFFLE_SEED: ${{ github.run_number }}
       - uses: codecov/codecov-action@v3


### PR DESCRIPTION
Default codecov GitHub Action expects "coverage.txt" file, which was not the name we used.